### PR TITLE
Feat: 커스텀 input 컴포넌트 생성

### DIFF
--- a/components/Form/CustomInput/index.tsx
+++ b/components/Form/CustomInput/index.tsx
@@ -1,0 +1,31 @@
+import { TextField } from '@mui/material';
+import { UseFormRegisterReturn } from 'react-hook-form';
+import { Container } from './style';
+
+interface CustomInputProps {
+  label: string;
+  register: UseFormRegisterReturn;
+  placeholderTxt: string;
+  inputType?: string;
+  autoFocus?: boolean;
+  errorMsg?: string;
+  value?: string;
+}
+
+export const CustomInput = (props: CustomInputProps) => {
+  const { label, value, register, autoFocus, inputType, placeholderTxt, errorMsg } = props;
+  return (
+    <Container>
+      <label>{label}</label>
+      <TextField
+        {...register}
+        defaultValue={value}
+        autoFocus={autoFocus || false}
+        type={inputType || 'text'}
+        placeholder={placeholderTxt}
+        error={errorMsg ? true : false}
+        helperText={errorMsg}
+      />
+    </Container>
+  );
+};

--- a/components/Form/CustomInput/style.tsx
+++ b/components/Form/CustomInput/style.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  padding: 15px 0;
+
+  label {
+    color: ${(props) => props.theme.colors.lightblue};
+    padding-bottom: 10px;
+  }
+
+  input {
+    background: #e6e6e6;
+    border-radius: 5px;
+    border: 0;
+    padding: 15px;
+  }
+
+  fieldset {
+    border: 0;
+  }
+`;

--- a/components/Form/index.ts
+++ b/components/Form/index.ts
@@ -1,1 +1,2 @@
 export * from './AuthInput';
+export * from './CustomInput';


### PR DESCRIPTION
[필수 props]
- label: input 상단 이름
- register: react-hook-form register
- placeholderTxt: placeholder 텍스트

[옵션 props]
- value: default value 값
- autoFocus: default 값 false
- types: default 값 text
- errorMsg: input validate 에러 메세지