### PR TITLE
Feat: 로그인 인증 체크 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log*
 next-env.d.ts
 
 .env
+.env.d.ts
 
 #package
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ yarn-error.log*
 next-env.d.ts
 
 .env
-.env.d.ts
+env.d.ts
 
 #package
 package-lock.json

--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -1,4 +1,4 @@
-import { RequestAuth, UpdateUserProfile } from 'types/auth';
+import { RequestAuth, UpdateUserProfile, UserInfoType } from 'types/auth';
 import { firebaseAuth } from 'services/firebase';
 import {
   createUserWithEmailAndPassword,
@@ -7,6 +7,7 @@ import {
   updateProfile,
   UserCredential,
 } from 'firebase/auth';
+import axios from 'axios';
 
 export const authAPI = {
   signin: (data: RequestAuth): Promise<UserCredential> => {
@@ -20,5 +21,22 @@ export const authAPI = {
   },
   updateProfile: (data: UpdateUserProfile): Promise<void> => {
     return updateProfile(data.user, { displayName: data.displayName });
+  },
+};
+
+export const localAuth = {
+  signin: async (token: string): Promise<UserInfoType> => {
+    const { data } = await axios({
+      method: 'POST',
+      url: '/api/auth/login',
+      data: { token },
+    });
+    return data.userInfo;
+  },
+  signout: async () => {
+    return await axios({
+      method: 'POST',
+      url: '/api/auth/logout',
+    });
   },
 };

--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -3,6 +3,7 @@ import { firebaseAuth } from 'services/firebase';
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  signOut,
   updateProfile,
   UserCredential,
 } from 'firebase/auth';
@@ -13,6 +14,9 @@ export const authAPI = {
   },
   signup: (data: RequestAuth): Promise<UserCredential> => {
     return createUserWithEmailAndPassword(firebaseAuth, data.email, data.password);
+  },
+  signout: (): Promise<void> => {
+    return signOut(firebaseAuth);
   },
   updateProfile: (data: UpdateUserProfile): Promise<void> => {
     return updateProfile(data.user, { displayName: data.displayName });

--- a/apis/database.ts
+++ b/apis/database.ts
@@ -1,5 +1,14 @@
-import { collection, doc, DocumentData, getDocs, QuerySnapshot, setDoc } from 'firebase/firestore';
+import {
+  collection,
+  doc,
+  DocumentData,
+  getDoc,
+  getDocs,
+  QuerySnapshot,
+  setDoc,
+} from 'firebase/firestore';
 import { firestore } from 'services/firebase';
+import { UserBodyInfoType } from 'types/auth';
 
 interface DocumentOption {
   collectionName: string;
@@ -7,10 +16,7 @@ interface DocumentOption {
 }
 
 interface BodyWriteDocument extends DocumentOption {
-  gender: string;
-  age: number;
-  height: number;
-  weight: number;
+  body: UserBodyInfoType;
 }
 
 interface ActiveWriteDocument extends DocumentOption {
@@ -23,14 +29,19 @@ export const db = {
   read: (collectionName: string): Promise<QuerySnapshot<DocumentData>> => {
     return getDocs(collection(firestore, collectionName));
   },
+  readDoc: async (data: DocumentOption): Promise<DocumentData | undefined> => {
+    return (await getDoc(doc(firestore, data.collectionName, data.documentName))).data();
+  },
   bodyWrite: (data: BodyWriteDocument): Promise<void> => {
     return setDoc(
       doc(firestore, data.collectionName, data.documentName),
       {
-        gender: data.gender,
-        age: data.age,
-        height: data.height,
-        weight: data.weight,
+        body: {
+          gender: data.body.gender,
+          age: data.body.age,
+          height: data.body.height,
+          weight: data.body.weight,
+        },
       },
       { merge: true }
     );

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,64 +1,23 @@
 import { Container } from './style';
-import { db } from 'apis/database';
-import { authState } from 'store/atoms';
 import { authAPI } from 'apis/auth';
-import { firebaseAuth } from 'services/firebase';
-import { onAuthStateChanged } from 'firebase/auth';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import axios from 'axios';
 
 export const Layout = ({ children }: React.PropsWithChildren) => {
   const router = useRouter();
-  const setUserInfo = useSetRecoilState(authState);
-  const resetUserInfo = useResetRecoilState(authState);
-  useEffect(() => {
-    onAuthStateChanged(firebaseAuth, async (user) => {
-      if (user) {
-        const getUserPersonalInfo = await db.readDoc({
-          collectionName: 'users',
-          documentName: user.uid,
-        });
-
-        setUserInfo((prev) => {
-          return {
-            ...prev,
-            uid: user.uid,
-            displayName: user?.displayName,
-            body: getUserPersonalInfo?.body || {
-              gender: '',
-              age: '',
-              height: '',
-              weight: '',
-            },
-          };
-        });
-      }
-    });
-  }, [router.pathname]);
-
-  useEffect(() => {
-    onAuthStateChanged(firebaseAuth, async (user) => {
-      if (user) {
-        if (router.pathname === '/signin' || router.pathname === '/signup') {
-          router.push('/');
-        }
-      } else {
-        resetUserInfo();
-        if (router.pathname !== '/signin' && router.pathname !== '/signup') {
-          router.push('/signin');
-        }
-      }
-    });
-  }, []);
+  const onSingOut = async () => {
+    await authAPI.signout();
+    await axios({ method: 'POST', url: '/api/auth/logout' });
+    router.push('/signin');
+  };
 
   return (
     <>
       <Head>
         <title>룰루트레이닝</title>
       </Head>
-      <button onClick={() => authAPI.signout()}>로그아웃</button>
+      <button onClick={onSingOut}>로그아웃</button>
       <Container>{children}</Container>
     </>
   );

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,14 +1,13 @@
 import { Container } from './style';
-import { authAPI } from 'apis/auth';
+import { authAPI, localAuth } from 'apis/auth';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import axios from 'axios';
 
 export const Layout = ({ children }: React.PropsWithChildren) => {
   const router = useRouter();
   const onSingOut = async () => {
     await authAPI.signout();
-    await axios({ method: 'POST', url: '/api/auth/logout' });
+    await localAuth.signout();
     router.push('/signin');
   };
 

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,27 +1,65 @@
 import { Container } from './style';
-import { UnathorizedResult } from 'components';
+import { db } from 'apis/database';
+import { authState } from 'store/atoms';
+import { authAPI } from 'apis/auth';
+import { firebaseAuth } from 'services/firebase';
+import { onAuthStateChanged } from 'firebase/auth';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
 
 export const Layout = ({ children }: React.PropsWithChildren) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const { pathname } = useRouter();
+  const router = useRouter();
+  const setUserInfo = useSetRecoilState(authState);
+  const resetUserInfo = useResetRecoilState(authState);
+  useEffect(() => {
+    onAuthStateChanged(firebaseAuth, async (user) => {
+      if (user) {
+        const getUserPersonalInfo = await db.readDoc({
+          collectionName: 'users',
+          documentName: user.uid,
+        });
+
+        setUserInfo((prev) => {
+          return {
+            ...prev,
+            uid: user.uid,
+            displayName: user?.displayName,
+            body: getUserPersonalInfo?.body || {
+              gender: '',
+              age: '',
+              height: '',
+              weight: '',
+            },
+          };
+        });
+      }
+    });
+  }, [router.pathname]);
 
   useEffect(() => {
-    if (pathname === '/signin' || pathname === '/signup') {
-      setIsModalOpen(false);
-    } else {
-      !localStorage.getItem('oz-user') && setIsModalOpen(true);
-    }
-  }, [pathname]);
+    onAuthStateChanged(firebaseAuth, async (user) => {
+      if (user) {
+        if (router.pathname === '/signin' || router.pathname === '/signup') {
+          router.push('/');
+        }
+      } else {
+        resetUserInfo();
+        if (router.pathname !== '/signin' && router.pathname !== '/signup') {
+          router.push('/signin');
+        }
+      }
+    });
+  }, []);
+
   return (
     <>
       <Head>
-        <title>오즈의 트레이닝</title>
+        <title>룰루트레이닝</title>
       </Head>
+      <button onClick={() => authAPI.signout()}>로그아웃</button>
       <Container>{children}</Container>
-      <UnathorizedResult isLogin={isModalOpen} />
     </>
   );
 };

--- a/consts/initialUserInfo.ts
+++ b/consts/initialUserInfo.ts
@@ -1,0 +1,11 @@
+export const InitialUserInfo = {
+  uid: '',
+  displayName: '',
+  body: {
+    gender: '',
+    age: '',
+    height: '',
+    weight: '',
+  },
+  active: {},
+};

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-  swcMinify: true,
-}
 
-module.exports = nextConfig
+const nextConfig = {
+  swcMinify: true,
+};
+
+module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 
 const nextConfig = {
   swcMinify: true,
+  reactStrictMode: true,
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "next": "13.0.5",
     "next-cookies": "^2.0.3",
     "react": "18.2.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.40.0",
     "recoil": "^0.7.6",
     "typescript": "4.9.3"
   },
   "devDependencies": {
-    "@types/cookie": "^0.5.1"
+    "@types/cookie": "^0.5.1",
+    "@types/uuid": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,13 +17,19 @@
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.8",
     "@uiball/loaders": "^1.2.6",
+    "axios": "^1.3.2",
+    "cookie": "^0.5.0",
     "firebase": "^9.15.0",
-    "framer-motion": "^8.1.9",
+    "firebase-admin": "^11.5.0",
     "next": "13.0.5",
+    "next-cookies": "^2.0.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.40.0",
     "recoil": "^0.7.6",
     "typescript": "4.9.3"
+  },
+  "devDependencies": {
+    "@types/cookie": "^0.5.1"
   }
 }

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -1,0 +1,20 @@
+import { serialize } from 'cookie';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { adminAuth } from 'services/admin';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { token } = req.body;
+  if (token) {
+    const getSessionCookie = await adminAuth.createSessionCookie(token, {
+      expiresIn: 336 * 60 * 60 * 1000,
+    });
+    const userToken = serialize('user', getSessionCookie, {
+      httpOnly: true,
+      path: '/',
+      expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+    });
+
+    res.setHeader('Set-Cookie', userToken);
+  }
+  res.status(200).json({ message: 'Successfully set cookie!' });
+};

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -1,17 +1,23 @@
+import { InitialUserInfo } from 'consts/initialUserInfo';
 import { serialize } from 'cookie';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { adminAuth } from 'services/admin';
+import { adminAuth, adminStore } from 'services/admin';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { token } = req.body;
   const verifyToken = async (token: string) => {
     return await adminAuth.verifyIdToken(token, true);
   };
+  const verifyUser = async (user: string) => {
+    return await adminAuth.verifySessionCookie(user, true);
+  };
   const createCookie = async (token: string) => {
     return await adminAuth.createSessionCookie(token, {
       expiresIn: 336 * 60 * 60 * 1000,
     });
   };
+
+  let userInfo = {};
 
   if (token) {
     try {
@@ -22,9 +28,21 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         path: '/',
         expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
       });
+
+      const { uid } = await verifyUser(getSessionCookie);
+      const { displayName } = await adminAuth.getUser(uid);
+      if (displayName) {
+        const userPersonalData = (await adminStore.doc(`users/${uid}`).get()).data();
+        if (userPersonalData) {
+          userInfo = { ...InitialUserInfo, ...userPersonalData, uid, displayName };
+        } else {
+          userInfo = { ...InitialUserInfo, uid, displayName };
+        }
+      }
       res.setHeader('Set-Cookie', userToken);
-      res.status(200).json({ message: 'Successfully set cookie!' });
+      res.status(200).json({ userInfo });
     } catch (error) {
+      console.log(error);
       res.status(401).json({ message: 'invlalid token' });
     }
   }

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -17,10 +17,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
           expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
         });
         res.setHeader('Set-Cookie', userToken);
+        res.status(200).json({ message: 'Successfully set cookie!' });
       })
       .catch(() => {
         res.status(401).json({ message: 'invlalid token' });
       });
   }
-  res.status(200).json({ message: 'Successfully set cookie!' });
 };

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -4,23 +4,28 @@ import { adminAuth } from 'services/admin';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { token } = req.body;
+  const verifyToken = async (token: string) => {
+    return await adminAuth.verifyIdToken(token, true);
+  };
+  const createCookie = async (token: string) => {
+    return await adminAuth.createSessionCookie(token, {
+      expiresIn: 336 * 60 * 60 * 1000,
+    });
+  };
+
   if (token) {
-    await adminAuth
-      .verifyIdToken(token)
-      .then(async () => {
-        const getSessionCookie = await adminAuth.createSessionCookie(token, {
-          expiresIn: 336 * 60 * 60 * 1000,
-        });
-        const userToken = serialize('user', getSessionCookie, {
-          httpOnly: true,
-          path: '/',
-          expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
-        });
-        res.setHeader('Set-Cookie', userToken);
-        res.status(200).json({ message: 'Successfully set cookie!' });
-      })
-      .catch(() => {
-        res.status(401).json({ message: 'invlalid token' });
+    try {
+      await verifyToken(token);
+      const getSessionCookie = await createCookie(token);
+      const userToken = serialize('user', getSessionCookie, {
+        httpOnly: true,
+        path: '/',
+        expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
       });
+      res.setHeader('Set-Cookie', userToken);
+      res.status(200).json({ message: 'Successfully set cookie!' });
+    } catch (error) {
+      res.status(401).json({ message: 'invlalid token' });
+    }
   }
 };

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -5,16 +5,22 @@ import { adminAuth } from 'services/admin';
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { token } = req.body;
   if (token) {
-    const getSessionCookie = await adminAuth.createSessionCookie(token, {
-      expiresIn: 336 * 60 * 60 * 1000,
-    });
-    const userToken = serialize('user', getSessionCookie, {
-      httpOnly: true,
-      path: '/',
-      expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
-    });
-
-    res.setHeader('Set-Cookie', userToken);
+    await adminAuth
+      .verifyIdToken(token)
+      .then(async () => {
+        const getSessionCookie = await adminAuth.createSessionCookie(token, {
+          expiresIn: 336 * 60 * 60 * 1000,
+        });
+        const userToken = serialize('user', getSessionCookie, {
+          httpOnly: true,
+          path: '/',
+          expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+        });
+        res.setHeader('Set-Cookie', userToken);
+      })
+      .catch(() => {
+        res.status(401).json({ message: 'invlalid token' });
+      });
   }
   res.status(200).json({ message: 'Successfully set cookie!' });
 };

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -2,10 +2,10 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { serialize } from 'cookie';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const userToken = serialize('user', 'no', {
+  const userToken = serialize('user', '', {
     httpOnly: true,
     path: '/',
-    expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+    expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
   });
   const userInfo = serialize('userProfile', '', {
     httpOnly: true,

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -1,0 +1,12 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { serialize } from 'cookie';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const userToken = serialize('user', 'no', {
+    httpOnly: true,
+    path: '/',
+    expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+  });
+  res.setHeader('Set-Cookie', userToken);
+  res.status(200).json({ message: 'Successfully remove cookie!' });
+};

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -7,6 +7,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     path: '/',
     expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
   });
-  res.setHeader('Set-Cookie', userToken);
+  const userInfo = serialize('userProfile', '', {
+    httpOnly: true,
+    path: '/',
+    expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  });
+  res.setHeader('Set-Cookie', [userToken, userInfo]);
   res.status(200).json({ message: 'Successfully remove cookie!' });
 };

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,18 +1,19 @@
-import { AuthError, CustomInput } from 'components';
-import { authAPI } from 'apis/auth';
+import { AuthError, CustomInput, Loader } from 'components';
+import { authAPI, localAuth } from 'apis/auth';
 import { RequestAuth } from 'types/auth';
 import { Container } from 'styles/siginin.style';
 import logoImage from '/public/images/logo.png';
 import { unAuthorizedCheck } from 'utils/unAuthorizedCheck';
+import { authState } from 'store/atoms';
 import { useForm } from 'react-hook-form';
 import { Button } from '@mui/material';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { FirebaseError } from 'firebase/app';
-import axios from 'axios';
 import { GetServerSidePropsContext } from 'next';
 import cookies from 'next-cookies';
+import { useSetRecoilState } from 'recoil';
 
 const Signin = () => {
   const {
@@ -22,6 +23,8 @@ const Signin = () => {
   } = useForm<RequestAuth>();
   const router = useRouter();
   const [signinError, setSigninError] = useState('');
+  const setUserData = useSetRecoilState(authState);
+  const [isLoading, setIsLoading] = useState(false);
   const onValidSignin = async ({ email, password }: RequestAuth) => {
     setSigninError('');
     try {
@@ -29,8 +32,12 @@ const Signin = () => {
         email,
         password,
       });
+      setIsLoading(true);
       const token = await user.getIdToken();
-      await axios({ method: 'POST', url: '/api/auth/login', data: { token } });
+      const userInfo = await localAuth.signin(token);
+      setUserData((prev) => {
+        return { ...prev, ...userInfo };
+      });
       router.push('/');
     } catch (error) {
       if (error instanceof FirebaseError) {
@@ -38,50 +45,55 @@ const Signin = () => {
       }
     }
   };
-
   return (
     <Container>
-      <div className="signin__title">
-        <h1>
-          <Image src={logoImage} alt="lulutraining-logo" priority />
-        </h1>
-        <p>로그인</p>
-      </div>
-      <form onSubmit={handleSubmit(onValidSignin)}>
-        <CustomInput
-          label="Email"
-          register={register('email', {
-            required: '이메일 형식에 맞게 입력해 주세요',
-            pattern: {
-              value: /[\w-_.]+@[\w]+\.[\w.]+/,
-              message: '이메일 형식에 맞게 입력해 주세요',
-            },
-          })}
-          type="text"
-          errorMsg={errors.email?.message}
-          placeholder="이메일 형식의 아이디를 입력해주세요"
-          autoFocus={true}
-        />
-        <CustomInput
-          label="Password"
-          register={register('password', {
-            required: '비밀번호는 6자 이상 입력해주세요',
-            minLength: {
-              value: 6,
-              message: '비밀번호는 6자 이상 입력해주세요',
-            },
-          })}
-          type="password"
-          errorMsg={errors.password?.message}
-          placeholder="비밀번호를 입력해주세요"
-          autoFocus={false}
-        />
-        <AuthError errorCode={signinError} />
-        <button className="signin-btn">로그인</button>
-      </form>
-      <Button className="signup-btn" onClick={() => router.push('/signup')}>
-        회원가입
-      </Button>
+      {isLoading ? (
+        <Loader />
+      ) : (
+        <>
+          <div className="signin__title">
+            <h1>
+              <Image src={logoImage} alt="lulutraining-logo" priority />
+            </h1>
+            <p>로그인</p>
+          </div>
+          <form onSubmit={handleSubmit(onValidSignin)}>
+            <CustomInput
+              label="Email"
+              register={register('email', {
+                required: '이메일 형식에 맞게 입력해 주세요',
+                pattern: {
+                  value: /[\w-_.]+@[\w]+\.[\w.]+/,
+                  message: '이메일 형식에 맞게 입력해 주세요',
+                },
+              })}
+              type="text"
+              errorMsg={errors.email?.message}
+              placeholder="이메일 형식의 아이디를 입력해주세요"
+              autoFocus={true}
+            />
+            <CustomInput
+              label="Password"
+              register={register('password', {
+                required: '비밀번호는 6자 이상 입력해주세요',
+                minLength: {
+                  value: 6,
+                  message: '비밀번호는 6자 이상 입력해주세요',
+                },
+              })}
+              type="password"
+              errorMsg={errors.password?.message}
+              placeholder="비밀번호를 입력해주세요"
+              autoFocus={false}
+            />
+            <AuthError errorCode={signinError} />
+            <button className="signin-btn">로그인</button>
+          </form>
+          <Button className="signup-btn" onClick={() => router.push('/signup')}>
+            회원가입
+          </Button>
+        </>
+      )}
     </Container>
   );
 };

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,15 +1,13 @@
 import { AuthError, CustomInput } from 'components';
 import { authAPI } from 'apis/auth';
 import { RequestAuth } from 'types/auth';
-import { authState } from 'store/atoms';
 import { Container } from 'styles/siginin.style';
 import logoImage from '/public/images/logo.png';
 import { useForm } from 'react-hook-form';
 import { Button } from '@mui/material';
-import { useSetRecoilState } from 'recoil';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FirebaseError } from 'firebase/app';
 
 const Signin = () => {
@@ -19,19 +17,14 @@ const Signin = () => {
     formState: { errors },
   } = useForm<RequestAuth>();
   const router = useRouter();
-  const setProfile = useSetRecoilState(authState);
   const [signinError, setSigninError] = useState('');
 
   const onValidSignin = async ({ email, password }: RequestAuth) => {
     setSigninError('');
     try {
-      const data = await authAPI.signin({
+      await authAPI.signin({
         email,
         password,
-      });
-      localStorage.setItem('oz-user', data.user.uid);
-      setProfile((prevProfile) => {
-        return { ...prevProfile, displayName: data.user.displayName || '' };
       });
       router.push('/');
     } catch (error) {
@@ -40,13 +33,6 @@ const Signin = () => {
       }
     }
   };
-
-  useEffect(() => {
-    const token = localStorage.getItem('oz-user');
-    if (token) {
-      router.push('/');
-    }
-  }, []);
 
   return (
     <Container>

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,5 +1,5 @@
 import { AuthError, CustomInput, Loader } from 'components';
-import { authAPI } from 'apis/auth';
+import { authAPI, localAuth } from 'apis/auth';
 import { RequestSignup } from 'types/auth';
 import logoImage from '/public/images/logo.png';
 import { Container } from 'styles/signup.style';
@@ -12,7 +12,6 @@ import { useState } from 'react';
 import { FirebaseError } from 'firebase/app';
 import { GetServerSidePropsContext } from 'next';
 import cookies from 'next-cookies';
-import axios from 'axios';
 
 const Signup = () => {
   const router = useRouter();
@@ -36,7 +35,7 @@ const Signup = () => {
         displayName: displayName,
       });
       const token = await user.getIdToken();
-      await axios({ method: 'POST', url: '/api/auth/login', data: { token } });
+      await localAuth.signin(token);
       router.push('/signup/body-check');
     } catch (error) {
       if (error instanceof FirebaseError) {

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -3,12 +3,16 @@ import { authAPI } from 'apis/auth';
 import { RequestSignup } from 'types/auth';
 import logoImage from '/public/images/logo.png';
 import { Container } from 'styles/signup.style';
+import { unAuthorizedCheck } from 'utils/unAuthorizedCheck';
 import { useForm } from 'react-hook-form';
 import { Button } from '@mui/material';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { FirebaseError } from 'firebase/app';
+import { GetServerSidePropsContext } from 'next';
+import cookies from 'next-cookies';
+import axios from 'axios';
 
 const Signup = () => {
   const router = useRouter();
@@ -31,6 +35,8 @@ const Signup = () => {
         user: user,
         displayName: displayName,
       });
+      const token = await user.getIdToken();
+      await axios({ method: 'POST', url: '/api/auth/login', data: { token } });
       router.push('/signup/body-check');
     } catch (error) {
       if (error instanceof FirebaseError) {
@@ -109,3 +115,8 @@ const Signup = () => {
 };
 
 export default Signup;
+
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const { user } = cookies(context);
+  return await unAuthorizedCheck({ user, context });
+};

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,22 +1,20 @@
 import { AuthError, CustomInput, Loader } from 'components';
 import { authAPI } from 'apis/auth';
-import { RequestSignup, UserProfile } from 'types/auth';
-import { authState } from 'store/atoms';
+import { RequestSignup } from 'types/auth';
 import logoImage from '/public/images/logo.png';
 import { Container } from 'styles/signup.style';
 import { useForm } from 'react-hook-form';
 import { Button } from '@mui/material';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FirebaseError } from 'firebase/app';
-import { useSetRecoilState } from 'recoil';
 
 const Signup = () => {
   const router = useRouter();
   const [signupError, setSignupError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const setUserProfile = useSetRecoilState<UserProfile>(authState);
+
   const {
     register,
     handleSubmit,
@@ -34,10 +32,6 @@ const Signup = () => {
         displayName: displayName,
       });
       router.push('/signup/body-check');
-      localStorage.setItem('oz-user', user.uid);
-      setUserProfile((prevProfile) => {
-        return { ...prevProfile, displayName: user.displayName || '' };
-      });
     } catch (error) {
       if (error instanceof FirebaseError) {
         setSignupError(`${error.code}`);
@@ -47,13 +41,6 @@ const Signup = () => {
       }
     }
   };
-
-  useEffect(() => {
-    const token = localStorage.getItem('oz-user');
-    if (token) {
-      router.push('/');
-    }
-  }, []);
 
   return (
     <Container>

--- a/services/admin.ts
+++ b/services/admin.ts
@@ -1,0 +1,13 @@
+import admin from 'firebase-admin';
+
+const adminConfig = {
+  credential: admin.credential.cert({
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    clientEmail: process.env.NEXT_PUBLIC_FIREBASE_CLIENT_EMAIL,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+  }),
+};
+
+export const firebaseAdmin = admin.apps.length ? admin.app() : admin.initializeApp(adminConfig);
+export const adminAuth = firebaseAdmin.auth();
+export const adminStore = firebaseAdmin.firestore();

--- a/store/atomEffect.ts
+++ b/store/atomEffect.ts
@@ -3,11 +3,13 @@ import { AtomEffect } from 'recoil';
 export const localStorageEffect =
   <T>(key: string): AtomEffect<T> =>
   ({ setSelf, onSet }) => {
-    const savedValue = localStorage.getItem(key);
-    if (savedValue != null) {
-      setSelf(JSON.parse(savedValue));
+    if (typeof window !== 'undefined') {
+      const savedValue = localStorage.getItem(key);
+      if (savedValue != null) {
+        setSelf(JSON.parse(savedValue));
+      }
+      onSet((newValue) => {
+        localStorage.setItem(key, JSON.stringify(newValue));
+      });
     }
-    onSet((newValue) => {
-      localStorage.setItem(key, JSON.stringify(newValue));
-    });
   };

--- a/store/atomEffect.ts
+++ b/store/atomEffect.ts
@@ -1,15 +1,20 @@
+import { Cookies } from 'react-cookie';
 import { AtomEffect } from 'recoil';
 
-export const localStorageEffect =
+export const setCookieEffect =
   <T>(key: string): AtomEffect<T> =>
   ({ setSelf, onSet }) => {
     if (typeof window !== 'undefined') {
-      const savedValue = localStorage.getItem(key);
+      const cookies = new Cookies();
+      const savedValue = cookies.get(key);
       if (savedValue != null) {
-        setSelf(JSON.parse(savedValue));
+        setSelf(savedValue);
       }
       onSet((newValue) => {
-        localStorage.setItem(key, JSON.stringify(newValue));
+        cookies.set(key, newValue, {
+          path: '/',
+          expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+        });
       });
     }
   };

--- a/store/atoms.ts
+++ b/store/atoms.ts
@@ -1,11 +1,18 @@
-import { UserProfile } from 'types/auth';
+import { UserBodyInfoType, UserProfile } from 'types/auth';
 import { localStorageEffect } from './atomEffect';
 import { atom } from 'recoil';
 
 export const authState = atom<UserProfile>({
   key: 'auth/profile',
   default: {
+    uid: '',
     displayName: '',
+    body: {
+      gender: '',
+      age: '',
+      height: '',
+      weight: '',
+    },
   },
   effects: [localStorageEffect('oz-user-profile')],
 });

--- a/store/atoms.ts
+++ b/store/atoms.ts
@@ -1,18 +1,11 @@
-import { UserBodyInfoType, UserProfile } from 'types/auth';
-import { localStorageEffect } from './atomEffect';
+import { UserInfoType } from 'types/auth';
+import { setCookieEffect } from './atomEffect';
 import { atom } from 'recoil';
+import { v1 } from 'uuid';
+import { InitialUserInfo } from 'consts/initialUserInfo';
 
-export const authState = atom<UserProfile>({
-  key: 'auth/profile',
-  default: {
-    uid: '',
-    displayName: '',
-    body: {
-      gender: '',
-      age: '',
-      height: '',
-      weight: '',
-    },
-  },
-  effects: [localStorageEffect('oz-user-profile')],
+export const authState = atom<UserInfoType>({
+  key: `auth/profile${v1()}`,
+  default: InitialUserInfo,
+  effects: [setCookieEffect('userProfile')],
 });

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -9,12 +9,6 @@ export interface RequestSignup extends RequestAuth {
   displayName: string;
 }
 
-export interface UserProfile {
-  uid: string;
-  displayName: string | null;
-  body: UserBodyInfoType;
-}
-
 export interface UpdateUserProfile {
   user: User;
   displayName: string;
@@ -28,6 +22,8 @@ export interface UserBodyInfoType {
 }
 
 export interface UserInfoType {
+  uid: string;
+  displayName: string;
   active: {
     [key: string]: number;
   };

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -10,9 +10,26 @@ export interface RequestSignup extends RequestAuth {
 }
 
 export interface UserProfile {
+  uid: string;
+  displayName: string | null;
+  body: UserBodyInfoType;
+}
+
+export interface UpdateUserProfile {
+  user: User;
   displayName: string;
 }
 
-export interface UpdateUserProfile extends UserProfile {
-  user: User;
+export interface UserBodyInfoType {
+  gender: string;
+  age: string;
+  height: string;
+  weight: string;
+}
+
+export interface UserInfoType {
+  active: {
+    [key: string]: number;
+  };
+  body: UserBodyInfoType;
 }

--- a/utils/unAuthorizedCheck.ts
+++ b/utils/unAuthorizedCheck.ts
@@ -36,10 +36,10 @@ export const unAuthorizedCheck = async (data: VerifyUserType) => {
         };
       }
     } catch (error) {
-      const userToken = serialize('user', 'no', {
+      const userToken = serialize('user', '', {
         httpOnly: true,
         path: '/',
-        expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+        expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
       });
       data.context.res.setHeader('Set-Cookie', userToken);
       if (current === '/bodycheck' || current === '/activecheck') {
@@ -49,6 +49,14 @@ export const unAuthorizedCheck = async (data: VerifyUserType) => {
           },
         };
       }
+    }
+  } else {
+    if (current === '/bodycheck' || current === '/activecheck') {
+      return {
+        redirect: {
+          destination: '/signin',
+        },
+      };
     }
   }
 

--- a/utils/unAuthorizedCheck.ts
+++ b/utils/unAuthorizedCheck.ts
@@ -1,0 +1,63 @@
+import { GetServerSidePropsContext } from 'next';
+import { adminAuth, adminStore } from 'services/admin';
+import { serialize } from 'cookie';
+
+interface UnAuthorizedCheck {
+  user: string | undefined;
+  context: GetServerSidePropsContext;
+  propsOption?: Object;
+}
+
+export const unAuthorizedCheck = async (data: UnAuthorizedCheck) => {
+  const current = data.context.resolvedUrl;
+  let userInfo = {
+    uid: '',
+    displayName: '',
+    body: {},
+    active: {},
+  };
+
+  if (data.user) {
+    await adminAuth
+      .verifySessionCookie(data.user, true)
+      .then(async (decode) => {
+        const userName = (await adminAuth.getUser(decode.uid)).displayName;
+        userInfo = { ...userInfo, uid: decode.uid, displayName: userName || '' };
+      })
+      .catch(async () => {
+        const userToken = serialize('user', 'no', {
+          httpOnly: true,
+          path: '/',
+          expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+        });
+        data.context.res.setHeader('Set-Cookie', userToken);
+      });
+
+    if (userInfo.uid) {
+      const getUserDatabase = (await adminStore.doc(`users/${userInfo.uid}`).get()).data();
+      userInfo = { ...userInfo, ...getUserDatabase };
+      if (current === '/signin' || current === '/signup') {
+        return {
+          redirect: {
+            destination: '/',
+          },
+        };
+      }
+    } else {
+      if (current !== '/signin' && current !== '/signup') {
+        return {
+          redirect: {
+            destination: '/signin',
+          },
+        };
+      }
+    }
+  }
+
+  return {
+    props: {
+      userInfo,
+      propsOption: data.propsOption || {},
+    },
+  };
+};

--- a/utils/unAuthorizedCheck.ts
+++ b/utils/unAuthorizedCheck.ts
@@ -1,3 +1,4 @@
+import { InitialUserInfo } from 'consts/initialUserInfo';
 import { GetServerSidePropsContext } from 'next';
 import { adminAuth, adminStore } from 'services/admin';
 import { serialize } from 'cookie';
@@ -13,10 +14,7 @@ export const unAuthorizedCheck = async (data: VerifyUserType) => {
   const verifyUser = async (user: string) => {
     return await adminAuth.verifySessionCookie(user, true);
   };
-  let userInfo = {
-    uid: '',
-    displayName: '',
-  };
+  let userInfo = {};
 
   if (data.user) {
     try {
@@ -24,7 +22,11 @@ export const unAuthorizedCheck = async (data: VerifyUserType) => {
       const { displayName } = await adminAuth.getUser(uid);
       if (displayName) {
         const userPersonalData = (await adminStore.doc(`users/${uid}`).get()).data();
-        userInfo = { ...userInfo, ...userPersonalData, uid, displayName };
+        if (userPersonalData) {
+          userInfo = { ...InitialUserInfo, ...userPersonalData, uid, displayName };
+        } else {
+          userInfo = { ...InitialUserInfo, uid, displayName };
+        }
       }
       if (current === '/signin' || current === '/signup') {
         return {


### PR DESCRIPTION
**1. package 추가 설치 및 삭제**
- framer-motion 삭제
- next-cookie, cookie, firebase-admin 추가

**2. next.config.js**
strictMode 때문에 두번 실행되서 에러가 계속 발생해서 우선 삭제했습니다.

**3. 로그인 인증 관련 코드**
✅ admin.ts
서버측에서 firebase 관리자로써 접근할 수 있는, firebase-admin SDK 파일

✅ pages/api/auth/login.ts
- 로그인시 유저의 고유 토큰 발급하여 post 요청 (data: token : ""}
- 응답으로 받아온 토큰 유효성 체크

> status 200
토큰 유효 => 쿠키값 (user): user 토큰 쿠키에 저장
return userInfo 데이터 

> status 401
토큰 유효 ❌ => invalid token

✅ pages/api/auth/logout.ts
- post 요청
- 유저 쿠키값 초기화

✅ unAuthorizedCheck.ts
- getServerSideProps에서 실행할 유틸 함수
- argument 
    user: geServerSideProps의 context에서 받아온 쿠키 값
    context: getServerSideProps의 context
    propsOption?: 추가로 리턴받고 싶은 props 데이터
 - 구현:
 
[유저가 유효한 경우]
- 쿠키에 유저 정보가 있다면 verifySessionCookie 로 쿠키가 유효한 값인지 체크
- 유효한 값이면 유저의 uid, displayName을 userInfo에 담아 props로 리턴
- 유저의 database(신체정보, 활동량체크등) 불러와서 userInfo 변수에 추가
- signin , signup 경로에서 메인으로 리다이렉트

[유저가 유효하지 않은 경우]
- 유저 쿠키값 삭제
- 유저의 로그인이 꼭 필요한 bodycheck , activecheck 페이지에서 로그인 페이지로 리다이렉트


**4. unAuthorizedCheck.ts 사용하기**


```
import cookies from 'next-cookies';
import { unAuthorizedCheck } from 'utils/unAuthorizedCheck';

export const getServerSideProps = async (context: GetServerSidePropsContext) => {
  const { user } = cookies(context); // cookie 값 객체로 변환해주는 역활
  return await unAuthorizedCheck({ user, context });
};
```
