### PR TITLE
Feat: next.js 서버 로그인/로그아웃 api 구현

### DIFF
--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -1,11 +1,13 @@
-import { RequestAuth, UpdateUserProfile } from 'types/auth';
+import { RequestAuth, UpdateUserProfile, UserInfoType } from 'types/auth';
 import { firebaseAuth } from 'services/firebase';
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  signOut,
   updateProfile,
   UserCredential,
 } from 'firebase/auth';
+import axios from 'axios';
 
 export const authAPI = {
   signin: (data: RequestAuth): Promise<UserCredential> => {
@@ -14,7 +16,27 @@ export const authAPI = {
   signup: (data: RequestAuth): Promise<UserCredential> => {
     return createUserWithEmailAndPassword(firebaseAuth, data.email, data.password);
   },
+  signout: (): Promise<void> => {
+    return signOut(firebaseAuth);
+  },
   updateProfile: (data: UpdateUserProfile): Promise<void> => {
     return updateProfile(data.user, { displayName: data.displayName });
+  },
+};
+
+export const localAuth = {
+  signin: async (token: string): Promise<UserInfoType> => {
+    const { data } = await axios({
+      method: 'POST',
+      url: '/api/auth/login',
+      data: { token },
+    });
+    return data.userInfo;
+  },
+  signout: async () => {
+    return await axios({
+      method: 'POST',
+      url: '/api/auth/logout',
+    });
   },
 };

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -1,0 +1,49 @@
+import { InitialUserInfo } from 'store/atoms';
+import { serialize } from 'cookie';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { adminAuth, adminStore } from 'services/admin';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const { token } = req.body;
+  const verifyToken = async (token: string) => {
+    return await adminAuth.verifyIdToken(token, true);
+  };
+  const verifyUser = async (user: string) => {
+    return await adminAuth.verifySessionCookie(user, true);
+  };
+  const createCookie = async (token: string) => {
+    return await adminAuth.createSessionCookie(token, {
+      expiresIn: 336 * 60 * 60 * 1000,
+    });
+  };
+
+  let userInfo = {};
+
+  if (token) {
+    try {
+      await verifyToken(token);
+      const getSessionCookie = await createCookie(token);
+      const userToken = serialize('user', getSessionCookie, {
+        httpOnly: true,
+        path: '/',
+        expires: new Date(Date.now() + 336 * 60 * 60 * 1000),
+      });
+
+      const { uid } = await verifyUser(getSessionCookie);
+      const { displayName } = await adminAuth.getUser(uid);
+      if (displayName) {
+        const userPersonalData = (await adminStore.doc(`users/${uid}`).get()).data();
+        if (userPersonalData) {
+          userInfo = { ...InitialUserInfo, ...userPersonalData, uid, displayName };
+        } else {
+          userInfo = { ...InitialUserInfo, uid, displayName };
+        }
+      }
+      res.setHeader('Set-Cookie', userToken);
+      res.status(200).json({ userInfo });
+    } catch (error) {
+      console.log(error);
+      res.status(401).json({ message: 'invlalid token' });
+    }
+  }
+};

--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { serialize } from 'cookie';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  const userToken = serialize('user', '', {
+    httpOnly: true,
+    path: '/',
+    expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  });
+  const userInfo = serialize('userProfile', '', {
+    httpOnly: true,
+    path: '/',
+    expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  });
+  res.setHeader('Set-Cookie', [userToken, userInfo]);
+  res.status(200).json({ message: 'Successfully remove cookie!' });
+};

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -9,10 +9,23 @@ export interface RequestSignup extends RequestAuth {
   displayName: string;
 }
 
-export interface UserProfile {
+export interface UpdateUserProfile {
+  user: User;
   displayName: string;
 }
 
-export interface UpdateUserProfile extends UserProfile {
-  user: User;
+export interface UserBodyInfoType {
+  gender: string;
+  age: string;
+  height: string;
+  weight: string;
+}
+
+export interface UserInfoType {
+  uid: string;
+  displayName: string;
+  active: {
+    [key: string]: number;
+  };
+  body: UserBodyInfoType;
 }


### PR DESCRIPTION
클라이언트에서 로그인시, Next.js 서버측에서 firebase-admin을 활용하여 로그인한 유저의 유효성 검증 & 유저의 데이터를 전달하기 위한 api 구현

## 1. pages/api/login.ts
클라이언트에서 로그인시 authAPI.signin()이후에 요청 해 줍니다.

```javascript
method: 'POST',
url: '/api/auth/login',
data: { token },
```
> status 200 : return userInfo{uid, displayName, active, body}
> status 401: return invalid token

### 변수 및 함수 
- token: 유저가 로그인한 후 `user.getIdToken()` 으로 발행한 고유 토큰
- verifyToken: 위 token으로 `verifyIdToken()`을 사용해 token 검증
- createCookie: 검증된 token을 바탕으로 `createSessionCookie()`을 사용하여 2주 기간의 sessionCookie 발행
  - ✅ sessionCookie는 firebase 서버 session에 지정한 기간만큼 저장되고 최대 2주까지 생성 가능합니다.
  - ✅ token을 사용하지 않는 이유는 token의 유효기간은 1시간 밖에 되지 않아서 token을 바탕으로 발행한 sessionCookie를 활용했습니다.
- verifyUser: 생성한 `sessionCookie`가 유효한 값인지 검증하는 함수
- userInfo: 요청 성공 후 response에 담아서 보내줄 유저의 데이터

### 구현
1. 요청시 전달받은 token `verifyToken`함수로 검증
2. `createCookie`함수로 sessionCookie 생성
3. 생성한 sessionCookie를 클라이언트 쿠키에 2주기간으로 저장
```javascript
    const userToken = serialize('user', getSessionCookie, {
        httpOnly: true, // true 설정시 클라이언트에서 직접 접근 막음 - XSS CRSF 공격 방지
        path: '/', // 서버로 요청시 쿠키를 포함할 경로
        expires: new Date(Date.now() + 336 * 60 * 60 * 1000), // 유효기간
      });
```
4. `verifyUser`함수로 로그인한 유저의 uid 가져오기
5. firebase-admin auth의 getUser함수로 유저의 displayName 가져오기
6. firebase-admin firestore에서 유저 uid로 저장된 유저의 데이터들 가져오기(신체정보 활동량 체크 등)
7. 유저의 데이터가 없을 경우에는 `InitialUserInfo`로 기본 값 가져와서 넣어주기

### 요청 성공시 응답 상태 (200)
```javascript
userInfo = {
 uid: user uid,
  displayName: user displayName,
  body: {
    gender: '',
    age: '',
    height: '',
    weight: '',
  },
  active: {},
}
```

> 요청 성공 후 응답으로 user의 데이터를 받으면, 이 데이터를 전역상태에 저장해서 사용합니다.

[참고: firebase-auth 토큰 확인](https://firebase.google.com/docs/auth/admin/verify-id-tokens?hl=ko)

## 2. pages/api/logout.ts
```javascript
 method: 'POST',
 url: '/api/auth/logout'
```
> status 200: Successfully remove cookie!

로그아웃시 저장되어 있던 토큰, 유저의 데이터 쿠키정보가 삭제 됩니다.