### PR TITLE
Feat: unAuthorizedCheck, removeCookie 유틸 함수 구현

### DIFF
--- a/pages/api/auth/logout.ts
+++ b/pages/api/auth/logout.ts
@@ -1,17 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { serialize } from 'cookie';
+import { removeCookie } from 'utils/removeCookie';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  const userToken = serialize('user', '', {
-    httpOnly: true,
-    path: '/',
-    expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
-  });
-  const userInfo = serialize('userProfile', '', {
-    httpOnly: true,
-    path: '/',
-    expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
-  });
-  res.setHeader('Set-Cookie', [userToken, userInfo]);
+  res.setHeader('Set-Cookie', [removeCookie('user'), removeCookie('userProfile')]);
   res.status(200).json({ message: 'Successfully remove cookie!' });
 };

--- a/utils/removeCookie.ts
+++ b/utils/removeCookie.ts
@@ -1,0 +1,9 @@
+import { serialize } from 'cookie';
+
+export const removeCookie = (key: string) => {
+  return serialize(key, '', {
+    httpOnly: true,
+    path: '/',
+    expires: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  });
+};

--- a/utils/unAuthorizedCheck.ts
+++ b/utils/unAuthorizedCheck.ts
@@ -1,0 +1,51 @@
+import { removeCookie } from './removeCookie';
+import { adminAuth } from 'services/admin';
+import { GetServerSidePropsContext } from 'next';
+
+export interface VerifyUserType {
+  user: string | undefined;
+  context: GetServerSidePropsContext;
+  propsOption?: Object;
+}
+
+export const unAuthorizedCheck = async (data: VerifyUserType) => {
+  const current = data.context.resolvedUrl;
+  const verifyUser = async (user: string) => {
+    return await adminAuth.verifySessionCookie(user, true);
+  };
+  if (data.user) {
+    try {
+      await verifyUser(data.user);
+      if (current === '/signin' || current === '/signup') {
+        return {
+          redirect: {
+            destination: '/',
+          },
+        };
+      }
+    } catch (error) {
+      data.context.res.setHeader('Set-Cookie', [removeCookie('user'), removeCookie('userProfile')]);
+      if (current === '/bodycheck' || current === '/activecheck') {
+        return {
+          redirect: {
+            destination: '/signin',
+          },
+        };
+      }
+    }
+  } else {
+    if (current === '/bodycheck' || current === '/activecheck') {
+      return {
+        redirect: {
+          destination: '/signin',
+        },
+      };
+    }
+  }
+
+  return {
+    props: {
+      propsOption: data.propsOption || {},
+    },
+  };
+};

--- a/utils/unAuthorizedCheck.ts
+++ b/utils/unAuthorizedCheck.ts
@@ -10,12 +10,10 @@ export interface VerifyUserType {
 
 export const unAuthorizedCheck = async (data: VerifyUserType) => {
   const current = data.context.resolvedUrl;
-  const verifyUser = async (user: string) => {
-    return await adminAuth.verifySessionCookie(user, true);
-  };
+
   if (data.user) {
     try {
-      await verifyUser(data.user);
+      await adminAuth.verifySessionCookie(data.user, true);
       if (current === '/signin' || current === '/signup') {
         return {
           redirect: {


### PR DESCRIPTION
### unAuthorizedCheck.ts
getServerSideProps 함수에서 사용할 유저 인증 체크 함수

✅ unAuthorizedCheck 파라미터

```javascript
  user: 쿠키에 담긴 user의 토큰
  context: GetServerSidePropsContext;
  propsOption?: props로 보내줄 데이터
```

props 데이터를 unAuthorizedCheck 내부에서 처리해주는 이유는
geServerSideProps 에서 unAuthorizedCheck를 return으로 처리해주어야 동작하기때문입니다.

#### 구현

1. user 쿠키가 존재하는 경우
  - `verifySessionCookie()`로 유저의 유효성 체크
  - 유효한 경우: 회원가입이나 로그인 페이지면 메인페이지로 리다이렉트
  - 유효하지 않는 경우: 저장되어있던 쿠키 삭제
    - 신체기입이나 활동량체크와 같이 로그인이 꼭 필요한 서비스 페이지에서는 로그인 페이지로 리다이렉트
  
 2.  user 쿠키가 존재하지 않는 경우
 - 신체기입이나 활동량체크와 같이 로그인이 꼭 필요한 서비스 페이지에서는 로그인 페이지로 리다이렉트
 
### removeCookie.ts
cookie 삭제하는 유틸 함수
unAuthorizedCheck.ts, api/auth/logout.ts 에서 사용하여 유틸함수로 분리했습니다.
  