### PR TITLE
Feat: app 초기 렌더링시 user data 초기값 저장

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,14 +1,24 @@
 import { Layout } from 'components';
 import { ResetStyle } from 'styles/global';
 import { theme } from 'styles/theme';
+import { UserInfoType } from 'types/auth';
+import { authState, InitialUserInfo } from 'store/atoms';
 import { Global } from '@emotion/react';
 import { ThemeProvider } from '@emotion/react';
-import type { AppProps } from 'next/app';
-import { RecoilRoot } from 'recoil';
+import { MutableSnapshot, RecoilRoot } from 'recoil';
+import cookies from 'next-cookies';
+import type { AppContext, AppProps } from 'next/app';
 
-export default function App({ Component, pageProps }: AppProps) {
+interface MyAppProps extends AppProps {
+  userProfile: UserInfoType;
+}
+
+export default function App({ Component, pageProps, userProfile }: MyAppProps) {
+  const initialState = ({ set }: MutableSnapshot) => {
+    set(authState, userProfile ? userProfile : InitialUserInfo);
+  };
   return (
-    <RecoilRoot>
+    <RecoilRoot initializeState={initialState}>
       <ThemeProvider theme={theme}>
         <Global styles={ResetStyle} />
         <Layout>
@@ -18,3 +28,8 @@ export default function App({ Component, pageProps }: AppProps) {
     </RecoilRoot>
   );
 }
+
+App.getInitialProps = async ({ ctx }: AppContext) => {
+  const { userProfile } = cookies(ctx);
+  return { userProfile };
+};


### PR DESCRIPTION
전역상태로 저장한 user data와 page의 pre-render의 static source가 일치하지 않아서 hydration error가 발생했습니다.

_app에서 렌더링 초기에 getInitialProps로 cookie 데이터를 미리 받아와서
recoil state를 초기화 시켜줌으로써 해결 했습니다.

###  참고
https://recoiljs.org/docs/api-reference/core/Snapshot#hooks
https://nextjs.org/docs/api-reference/data-fetching/get-initial-props

[nextjs-hydrate error]
https://nextjs.org/docs/messages/react-hydration-error
