### PR TITLE
Feat: recoil atomEffect localstorage에서 cookie 저장으로 변경

### DIFF
--- a/store/atomEffect.ts
+++ b/store/atomEffect.ts
@@ -1,13 +1,20 @@
+import { Cookies } from 'react-cookie';
 import { AtomEffect } from 'recoil';
 
-export const localStorageEffect =
+export const setCookieEffect =
   <T>(key: string): AtomEffect<T> =>
   ({ setSelf, onSet }) => {
-    const savedValue = localStorage.getItem(key);
-    if (savedValue != null) {
-      setSelf(JSON.parse(savedValue));
+    if (typeof window !== 'undefined') {
+      const cookies = new Cookies();
+      const savedValue = cookies.get(key);
+      if (savedValue != null) {
+        setSelf(savedValue);
+      }
+      onSet((newValue) => {
+        cookies.set(key, newValue, {
+          path: '/',
+          expires: new Date(Date.now() + 24 * 14 * 60 * 60 * 1000),
+        });
+      });
     }
-    onSet((newValue) => {
-      localStorage.setItem(key, JSON.stringify(newValue));
-    });
   };

--- a/store/atoms.ts
+++ b/store/atoms.ts
@@ -1,11 +1,22 @@
-import { UserProfile } from 'types/auth';
-import { localStorageEffect } from './atomEffect';
+import { UserInfoType } from 'types/auth';
+import { setCookieEffect } from './atomEffect';
 import { atom } from 'recoil';
+import { v1 } from 'uuid';
 
-export const authState = atom<UserProfile>({
-  key: 'auth/profile',
-  default: {
-    displayName: '',
+export const InitialUserInfo = {
+  uid: '',
+  displayName: '',
+  body: {
+    gender: '',
+    age: '',
+    height: '',
+    weight: '',
   },
-  effects: [localStorageEffect('oz-user-profile')],
+  active: {},
+};
+
+export const authState = atom<UserInfoType>({
+  key: `auth/profile${v1()}`,
+  default: InitialUserInfo,
+  effects_UNSTABLE: [setCookieEffect('userProfile')],
 });


### PR DESCRIPTION
```javascript
 key: `auth/profile${v1()}`,
```

uuid의 v1은 Next.js 특성상 key가 중복된다는 에러를 해결하고자 추가했습니다.

https://velog.io/@sj_dev_js/Recoil-Duplicate-atom-key