### PR TITLE
fix: database readDoc api undefined 조건 삭제

### DIFF
--- a/apis/database.ts
+++ b/apis/database.ts
@@ -29,8 +29,8 @@ export const db = {
   read: (collectionName: string): Promise<QuerySnapshot<DocumentData>> => {
     return getDocs(collection(firestore, collectionName));
   },
-  readDoc: async (data: DocumentOption): Promise<DocumentData | undefined> => {
-    return (await getDoc(doc(firestore, data.collectionName, data.documentName))).data();
+  readDoc: async (data: DocumentOption): Promise<DocumentData> => {
+    return await getDoc(doc(firestore, data.collectionName, data.documentName));
   },
   bodyWrite: (data: BodyWriteDocument): Promise<void> => {
     return setDoc(


### PR DESCRIPTION
- 조건에 undefined 사용 지양을 위해 삭제
- `readDoc`을 사용하는 api에 return 값에 `.data()`를 추가하는 작업 필요